### PR TITLE
Enter name login

### DIFF
--- a/main.py
+++ b/main.py
@@ -34,6 +34,10 @@ if "user_id" not in st.session_state:
     with st.container(horizontal=True, horizontal_alignment="right"):
         if st.button("　開始　", type="primary", disabled=r):
             st.session_state["user_id"] = user_id
+            #nameを一応データベースに保存
+            db.collection("users").document(st.session_state["user_id"]).set({
+                "name": firestore.ArrayUnion([user_name])
+            }, merge=True)
             st.rerun()
     st.stop()
 


### PR DESCRIPTION
学籍番号とともに、名前も入力し、ログインするようにしました。
ログインは、エンター押しではなく、開始ボタンを設置
開始ボタンは学籍番号と名前両方入力されていないと使えません。
また、学籍番号は半角じゃなくても数字なら通るようにしました。

名前に関しては、データベースに一応保存するようにしました。
現時点で、名前をデータベースから取得したり、紐付けたりすることはないです。

closes #24 